### PR TITLE
DM-20148: add attr_name, sal_name, dds_name and rev_code attributes to BaseTopic

### DIFF
--- a/python/lsst/ts/salobj/base_csc.py
+++ b/python/lsst/ts/salobj/base_csc.py
@@ -275,7 +275,7 @@ class BaseCsc(Controller):
 
     @property
     def simulation_mode(self):
-        """Get or set the current simulation mode.
+        """Get the current simulation mode.
 
         0 means normal operation (no simulation).
 

--- a/python/lsst/ts/salobj/controller.py
+++ b/python/lsst/ts/salobj/controller.py
@@ -146,7 +146,7 @@ class Controller:
                 self._assert_do_methods_present(command_names)
             for cmd_name in command_names:
                 cmd = ControllerCommand(self.salinfo, cmd_name)
-                setattr(self, "cmd_" + cmd_name, cmd)
+                setattr(self, cmd.attr_name, cmd)
                 if do_callbacks:
                     func = getattr(self, f"do_{cmd_name}", None)
                     if func:
@@ -156,11 +156,11 @@ class Controller:
 
             for evt_name in self.salinfo.event_names:
                 evt = ControllerEvent(self.salinfo, evt_name)
-                setattr(self, "evt_" + evt_name, evt)
+                setattr(self, evt.attr_name, evt)
 
             for tel_name in self.salinfo.telemetry_names:
                 tel = ControllerTelemetry(self.salinfo, tel_name)
-                setattr(self, "tel_" + tel_name, tel)
+                setattr(self, tel.attr_name, tel)
 
             for required_name in ("logMessage", "logLevel"):
                 if not hasattr(self, f"evt_{required_name}"):

--- a/python/lsst/ts/salobj/remote.py
+++ b/python/lsst/ts/salobj/remote.py
@@ -143,7 +143,7 @@ class Remote:
             if not readonly:
                 for cmd_name in salinfo.command_names:
                     cmd = RemoteCommand(salinfo, cmd_name)
-                    setattr(self, "cmd_" + cmd_name, cmd)
+                    setattr(self, cmd.attr_name, cmd)
 
             for evt_name in salinfo.event_names:
                 if include_set is not None and evt_name not in include_set:
@@ -151,7 +151,7 @@ class Remote:
                 elif exclude_set and evt_name in exclude_set:
                     continue
                 evt = RemoteEvent(salinfo, evt_name, max_history=evt_max_history)
-                setattr(self, "evt_" + evt_name, evt)
+                setattr(self, evt.attr_name, evt)
 
             for tel_name in salinfo.telemetry_names:
                 if include_set is not None and tel_name not in include_set:
@@ -159,7 +159,7 @@ class Remote:
                 elif exclude_set and tel_name in exclude_set:
                     continue
                 tel = RemoteTelemetry(salinfo, tel_name, max_history=tel_max_history)
-                setattr(self, "tel_" + tel_name, tel)
+                setattr(self, tel.attr_name, tel)
 
             if start:
                 self.start_task = asyncio.ensure_future(self.start())

--- a/python/lsst/ts/salobj/topics/base_topic.py
+++ b/python/lsst/ts/salobj/topics/base_topic.py
@@ -59,32 +59,39 @@ class BaseTopic(abc.ABC):
             """The ``name`` constructor argument.
             """
 
-            self.attr_prefix = _ATTR_PREFIXES.get(sal_prefix)
-            """Prefix used for attributes of `Controller` and `Remote`.
-
-            * "cmd_" for commands
-            * "evt_" for events
-            * "tel_" for telemetry
-            """
-
-            self.attr_name = self.attr_prefix + name
-            """Name of topic attribute in `Controller` and `Remote`.
-            """
-
-            if self.attr_prefix is None:
-                raise ValueError(f"Uknown sal_prefix {sal_prefix!r}")
             self.sal_name = sal_prefix + self.name
             self.log = salinfo.log.getChild(self.sal_name)
+
             if name == "ackcmd":
+                attr_prefix = "ack_"
                 dds_name = f"{salinfo.name}_ackcmd"
                 rev_name = f"{salinfo.name}::ackcmd"
                 rev_code = ""
             else:
+                attr_prefix = _ATTR_PREFIXES.get(sal_prefix)
+                if attr_prefix is None:
+                    raise ValueError(f"Uknown sal_prefix {sal_prefix!r}")
+
                 rev_name = salinfo.revnames.get(self.sal_name)
                 if rev_name is None:
                     raise ValueError(f"Could not find {self.salinfo.name} topic {self.sal_name}")
                 dds_name = rev_name.replace("::", "_")
                 rev_code = dds_name[-8:]
+
+            self.attr_prefix = attr_prefix
+            """Prefix used for attributes of `Controller` and `Remote`.
+
+            * "cmd_" for commands
+            * "evt_" for events
+            * "tel_" for telemetry
+            * "ack_" for ackcmd (but this topic is not
+                     an attribute of `Controller` or `Remote`
+            """
+
+            self.attr_name = attr_prefix + name
+            """Name of topic attribute in `Controller` and `Remote`.
+            """
+
             self.dds_name = dds_name
             """Name of topic in DDS.
             """

--- a/python/lsst/ts/salobj/topics/base_topic.py
+++ b/python/lsst/ts/salobj/topics/base_topic.py
@@ -78,16 +78,6 @@ class BaseTopic(abc.ABC):
                 dds_name = rev_name.replace("::", "_")
                 rev_code = dds_name[-8:]
 
-            self.attr_prefix = attr_prefix
-            """Prefix used for attributes of `Controller` and `Remote`.
-
-            * "cmd_" for commands
-            * "evt_" for events
-            * "tel_" for telemetry
-            * "ack_" for ackcmd (but this topic is not
-                     an attribute of `Controller` or `Remote`
-            """
-
             self.attr_name = attr_prefix + name
             """Name of topic attribute in `Controller` and `Remote`.
             """

--- a/python/lsst/ts/salobj/topics/base_topic.py
+++ b/python/lsst/ts/salobj/topics/base_topic.py
@@ -67,22 +67,34 @@ class BaseTopic(abc.ABC):
             * "tel_" for telemetry
             """
 
+            self.attr_name = self.attr_prefix + name
+            """Name of topic attribute in `Controller` and `Remote`.
+            """
+
             if self.attr_prefix is None:
                 raise ValueError(f"Uknown sal_prefix {sal_prefix!r}")
-            self._sal_topic_name = sal_prefix + self.name
-            self.log = salinfo.log.getChild(self._sal_topic_name)
+            self.sal_name = sal_prefix + self.name
+            self.log = salinfo.log.getChild(self.sal_name)
             if name == "ackcmd":
-                ddsname = f"{salinfo.name}_ackcmd"
-                revname = f"{salinfo.name}::ackcmd"
-                self._revCode = ""
+                dds_name = f"{salinfo.name}_ackcmd"
+                rev_name = f"{salinfo.name}::ackcmd"
+                rev_code = ""
             else:
-                revname = salinfo.revnames.get(self._sal_topic_name)
-                if revname is None:
-                    raise ValueError(f"Could not find {self.salinfo.name} topic {self._sal_topic_name}")
-                ddsname = revname.replace("::", "_")
-                self._revCode = ddsname[-8:]
-            self._type = ddsutil.get_dds_classes_from_idl(salinfo.idl_loc, revname)
-            self._topic = self._type.register_topic(salinfo.domain.participant, ddsname,
+                rev_name = salinfo.revnames.get(self.sal_name)
+                if rev_name is None:
+                    raise ValueError(f"Could not find {self.salinfo.name} topic {self.sal_name}")
+                dds_name = rev_name.replace("::", "_")
+                rev_code = dds_name[-8:]
+            self.dds_name = dds_name
+            """Name of topic in DDS.
+            """
+
+            self.rev_code = rev_code
+            """Revision code suffix on DDS topic name.
+            """
+
+            self._type = ddsutil.get_dds_classes_from_idl(salinfo.idl_loc, rev_name)
+            self._topic = self._type.register_topic(salinfo.domain.participant, dds_name,
                                                     salinfo.domain.topic_qos)
         except Exception as e:
             raise RuntimeError(f"Failed to create topic {salinfo.name}.{name}") from e

--- a/python/lsst/ts/salobj/topics/write_topic.py
+++ b/python/lsst/ts/salobj/topics/write_topic.py
@@ -134,7 +134,7 @@ class WriteTopic(BaseTopic):
             self.data.priority = priority
         curr_utc = time.time()
         self.data.private_sndStamp = base.tai_from_utc(curr_utc)
-        self.data.private_revCode = self._revCode
+        self.data.private_revCode = self.rev_code
         self.data.private_host = self.salinfo.domain.host
         self.data.private_origin = self.salinfo.domain.origin
         if self._seq_num_generator is not None:

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -48,28 +48,40 @@ class TopicsTestCase(unittest.TestCase):
                     remote_cmd = getattr(harness.remote, f"cmd_{cmd_name}")
                     self.assertEqual(remote_cmd.name, cmd_name)
                     self.assertEqual(remote_cmd.attr_prefix, "cmd_")
+                    self.assertEqual(remote_cmd.attr_name, "cmd_" + cmd_name)
+                    self.assertEqual(remote_cmd.sal_name, "command_" + cmd_name)
 
                     controller_cmd = getattr(harness.csc, f"cmd_{cmd_name}")
                     self.assertEqual(controller_cmd.name, cmd_name)
                     self.assertEqual(controller_cmd.attr_prefix, "cmd_")
+                    self.assertEqual(controller_cmd.attr_name, "cmd_" + cmd_name)
+                    self.assertEqual(controller_cmd.sal_name, "command_" + cmd_name)
 
                 for evt_name in harness.csc.salinfo.event_names:
                     remote_evt = getattr(harness.remote, f"evt_{evt_name}")
                     self.assertEqual(remote_evt.name, evt_name)
                     self.assertEqual(remote_evt.attr_prefix, "evt_")
+                    self.assertEqual(remote_evt.attr_name, "evt_" + evt_name)
+                    self.assertEqual(remote_evt.sal_name, "logevent_" + evt_name)
 
                     controller_evt = getattr(harness.csc, f"evt_{evt_name}")
                     self.assertEqual(controller_evt.name, evt_name)
                     self.assertEqual(controller_evt.attr_prefix, "evt_")
+                    self.assertEqual(controller_evt.attr_name, "evt_" + evt_name)
+                    self.assertEqual(controller_evt.sal_name, "logevent_" + evt_name)
 
                 for tel_name in harness.csc.salinfo.telemetry_names:
                     remote_tel = getattr(harness.remote, f"tel_{tel_name}")
                     self.assertEqual(remote_tel.name, tel_name)
                     self.assertEqual(remote_tel.attr_prefix, "tel_")
+                    self.assertEqual(remote_tel.attr_name, "tel_" + tel_name)
+                    self.assertEqual(remote_tel.sal_name, tel_name)
 
                     controller_tel = getattr(harness.csc, f"tel_{tel_name}")
                     self.assertEqual(controller_tel.name, tel_name)
                     self.assertEqual(controller_tel.attr_prefix, "tel_")
+                    self.assertEqual(controller_tel.attr_name, "tel_" + tel_name)
+                    self.assertEqual(controller_tel.sal_name, tel_name)
 
         asyncio.get_event_loop().run_until_complete(doit())
 

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -69,7 +69,8 @@ class TopicsTestCase(unittest.TestCase):
                         self.assertEqual(tel.dds_name,
                                          tel.salinfo.name + "_" + tel.sal_name + "_" + tel.rev_code)
 
-                # cannot add new topics to the existing SalInfo, so create a new SalInfo
+                # cannot add new topics to the existing salinfos
+                # (because the read loop has started) so create a new one
                 salinfo = salobj.SalInfo(domain=harness.csc.salinfo.domain,
                                          name=harness.csc.salinfo.name,
                                          index=harness.csc.salinfo.index)
@@ -92,17 +93,14 @@ class TopicsTestCase(unittest.TestCase):
                 for cmd_name in salinfo.command_names:
                     cmd = salobj.topics.BaseTopic(salinfo=salinfo, name=cmd_name, sal_prefix="command_")
                     self.assertEqual(cmd.name, cmd_name)
-                    self.assertEqual(cmd.attr_prefix, "cmd_")
 
                 for evt_name in salinfo.event_names:
                     evt = salobj.topics.BaseTopic(salinfo=salinfo, name=evt_name, sal_prefix="logevent_")
                     self.assertEqual(evt.name, evt_name)
-                    self.assertEqual(evt.attr_prefix, "evt_")
 
                 for tel_name in salinfo.telemetry_names:
                     tel = salobj.topics.BaseTopic(salinfo=salinfo, name=tel_name, sal_prefix="")
                     self.assertEqual(tel.name, tel_name)
-                    self.assertEqual(tel.attr_prefix, "tel_")
 
         asyncio.get_event_loop().run_until_complete(doit())
 


### PR DESCRIPTION
and remove attr_prefix.
Also use ack_ as the attribute name prefix for the ackcmd topic, instead of the misleading "tel_".
Some of these changes are for the Kafka producer but attr_name is an improvement over using attr_prefix in the Watcher.