### PR TITLE
Remove new commander prompt

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -25,7 +25,6 @@ Other changes:
   file in `ConfigurableCsc`.
 * `ConfigurableCsc.get_default_config_dir` renamed to
   `ConfigurableCsc._get_default_config_dir`.
-* Added a prompt to `CscCommander`.
 
 Requirements:
 

--- a/python/lsst/ts/salobj/csc_commander.py
+++ b/python/lsst/ts/salobj/csc_commander.py
@@ -66,7 +66,6 @@ async def stream_as_generator(stream, encoding="utf-8"):
     reader_protocol = asyncio.StreamReaderProtocol(reader)
     await loop.connect_read_pipe(lambda: reader_protocol, sys.stdin)
     while True:
-        print("> ", end="", flush=True)
         line = await reader.readline()
         if not line:  # EOF.
             break


### PR DESCRIPTION
It was a good idea, but because CSC commands are executed asynchronously, it comes too soon to be useful.