### PR TITLE
DM-26517: add valid_simulation_modes class attribute to BaseCsc

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -22,14 +22,29 @@ Backward Incompatible Changes:
 * Removed deprecated support for setting ``BaseCsc.summary_state`` directly.
   To transition your CSC to a FAULT state call the `BaseCsc.fault` method.
   Unit tests may call the `set_summary_state` function or issue the usual state transition commands.
-* Renamed `ControllerCommand.ackInProgress` to `ControllerCommand.ack_in_progress` and added a required `timeout` argument.
 * Commands are no longer acknowledged with ``CMD_INPROGRESS`` if the do_xxx callback function is asynchronous.
   This was needlessly chatty.
-  Instead users are expected to issue such an ack manually (e.g. by calling `topics.ControllerCommand.ack_in_progress`) when beginning to execute a command that will take significant time before it is reported as ``CMD_COMPLETE``.
-* Renamed `SalInfo.makeAckCmd` to `SalInfo.make_ackcmd`.
+  Instead users are expected to issue such an ack manually (e.g. by calling `topics.ControllerCommand.ack_in_progress`)
+  when beginning to execute a command that will take significant time before it is reported as ``CMD_COMPLETE``.
 * Removed the deprecated `SalInfo.idl_loc` property; use ``SalInfo.metadata.idl_path`` instead.
 * The `force_output` argument to `topics.ControllerEvent.set_put` is now keyword-only.
 * Removed ``bin/purge_topics.py`` command-line script, because it is no longer needed.
+
+Deprecations:
+
+* Simplified simulation mode support in CSCs.
+  This is described in :ref:`simulation mode<lsst.ts.salobj-simulation_mode>` and results in the following deprecations:
+
+  * CSCs should now set class variable ``valid_simulation_modes``, even if they do not support simulation.
+    Failure to do so will result in a deprecation warning, but supports the old way of doing things.
+  * Deprecated `BaseCsc.implement_simulation_mode`.
+    Start your simulator in whichever other method seems most appropriate.
+  * Deprecated the need to override `BaseCsc.add_arguments` and `BaseCsc.add_kwargs_from_args` to add the ``--simulate`` command-line argument.
+    This argument is added automatically if ``valid_simulation_modes`` has more than one entry.
+* Renamed `SalInfo.makeAckCmd` to `SalInfo.make_ackcmd`.
+  The old method is still available, but issues a deprecation warning.
+* Renamed `ControllerCommand.ackInProgress` to `ControllerCommand.ack_in_progress` and added a required `timeout` argument.
+   The old method is still available, but issues a deprecation warning.
 * `Remote`: the ``tel_max_history`` constructor argument is deprecated and should not be specified.
   If specified it must be 0 (or `None`, but please don't do that).
 * `topics.RemoteTelemetry`: the ``max_history`` constructor argument is deprecated and should not be specified.
@@ -38,7 +53,8 @@ Backward Incompatible Changes:
 Changes:
 
 * Implemented authorization support.
-  This version will communicate with ts_sal 4.2 and ts_salobj 5, but authorization support will be limited until the whole system uses ts_sal 5 and ts_salobj 6.
+  This will not be complete until ts_sal has full support.
+* Simplified the simulation support in CSCs, as explained in Deprecations above.
 * `CscCommander` now rounds float arrays when displaying events and telemetry (it already rounded float scalars).
 * Added support for running without a durability service:
   set environment variable ``LSST_DDS_HISTORYSYNC`` to a negative value to prevent waiting for historical data.
@@ -51,6 +67,7 @@ Changes:
   This encourages the user to properly commit the necessary reformatting.
 * Update ``Jenkinsfile`` to disable concurrent builds and clean up old log files.
 * Removed the ``.travis.yml`` file because it duplicates testing done in Jenkins.
+* Use `asynco.create_task` instead of deprecated `asyncio.ensure_future`.
 
 Requirements:
 

--- a/python/lsst/ts/salobj/base_csc.py
+++ b/python/lsst/ts/salobj/base_csc.py
@@ -120,13 +120,9 @@ class BaseCsc(Controller):
         * Set ``self.start_task`` done.
         """
         await super().start()
-        try:
-            self._heartbeat_task.cancel()  # Paranoia
-            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-            await self.set_simulation_mode(self._requested_simulation_mode)
-        except Exception as e:
-            await self.close(exception=e)
-            raise
+        self._heartbeat_task.cancel()  # Paranoia
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        await self.set_simulation_mode(self._requested_simulation_mode)
 
         await self.handle_summary_state()
         self.report_summary_state()

--- a/python/lsst/ts/salobj/base_csc.py
+++ b/python/lsst/ts/salobj/base_csc.py
@@ -121,7 +121,8 @@ class BaseCsc(Controller):
         """
         await super().start()
         try:
-            self._heartbeat_task = asyncio.ensure_future(self._heartbeat_loop())
+            self._heartbeat_task.cancel()  # Paranoia
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
             await self.set_simulation_mode(self._requested_simulation_mode)
         except Exception as e:
             await self.close(exception=e)
@@ -266,7 +267,7 @@ class BaseCsc(Controller):
         """
         await self._do_change_state(data, "exitControl", [State.STANDBY], State.OFFLINE)
 
-        asyncio.ensure_future(self.close())
+        asyncio.create_task(self.close())
 
     async def do_standby(self, data):
         """Transition from `State.DISABLED` or `State.FAULT` to
@@ -494,7 +495,7 @@ class BaseCsc(Controller):
                     "some code may not have run."
                 )
                 self.evt_summaryState.set_put(summaryState=self._summary_state)
-            asyncio.ensure_future(self.handle_summary_state())
+            asyncio.create_task(self.handle_summary_state())
         finally:
             self._faulting = False
 

--- a/python/lsst/ts/salobj/controller.py
+++ b/python/lsst/ts/salobj/controller.py
@@ -217,10 +217,10 @@ class Controller:
             # This task is set done when the CSC is fully started.
             # If `start` fails then the task has an exception set
             # and the CSC is not usable.
-            self.start_task = asyncio.ensure_future(self.start())
+            self.start_task = asyncio.create_task(self.start())
 
         except Exception:
-            asyncio.ensure_future(domain.close())
+            asyncio.create_task(domain.close())
             raise
 
     async def start(self):

--- a/python/lsst/ts/salobj/remote.py
+++ b/python/lsst/ts/salobj/remote.py
@@ -189,9 +189,9 @@ class Remote:
                 setattr(self, tel.attr_name, tel)
 
             if start:
-                self.start_task = asyncio.ensure_future(self.start())
+                self.start_task = asyncio.create_task(self.start())
         except Exception:
-            asyncio.ensure_future(self.salinfo.close())
+            asyncio.create_task(self.salinfo.close())
             raise
 
     async def start(self):

--- a/python/lsst/ts/salobj/sal_info.py
+++ b/python/lsst/ts/salobj/sal_info.py
@@ -612,7 +612,7 @@ class SalInfo:
                         sd_list = sd_list[-reader.max_history :]
                         if sd_list:
                             reader._queue_data(sd_list)
-            self._read_loop_task = asyncio.ensure_future(self._read_loop())
+            self._read_loop_task = asyncio.create_task(self._read_loop())
             self.start_task.set_result(None)
         except Exception as e:
             self.start_task.set_exception(e)

--- a/python/lsst/ts/salobj/sal_info.py
+++ b/python/lsst/ts/salobj/sal_info.py
@@ -26,6 +26,7 @@ import concurrent
 import logging
 import os
 import time
+import warnings
 
 import dds
 import ddsutil
@@ -423,6 +424,14 @@ class SalInfo:
             result=result,
             timeout=timeout,
         )
+
+    def makeAckCmd(self, *args, **kwargs):
+        """Deprecated version of make_ackcmd."""
+        # TODO DM-26518: remove this method
+        warnings.warn(
+            f"makeAckCmd is deprecated; use make_ackcmd instead.", DeprecationWarning
+        )
+        return self.make_ackcmd(*args, **kwargs)
 
     def __repr__(self):
         return f"SalBase({self.name}, {self.index})"

--- a/python/lsst/ts/salobj/testcsc.py
+++ b/python/lsst/ts/salobj/testcsc.py
@@ -91,6 +91,7 @@ class TestCsc(ConfigurableCsc):
     * 1: the fault command was executed
     """
 
+    valid_simulation_modes = [0]
     __test__ = False  # stop pytest from warning that this is not a test
 
     def __init__(

--- a/python/lsst/ts/salobj/topics/controller_command.py
+++ b/python/lsst/ts/salobj/topics/controller_command.py
@@ -23,6 +23,7 @@ __all__ = ["AckCmdWriter", "ControllerCommand"]
 
 import asyncio
 import inspect
+import warnings
 
 from .. import sal_enums
 from .. import base
@@ -117,6 +118,15 @@ class ControllerCommand(read_topic.ReadTopic):
             timeout=ackcmd.timeout,
         )
         self.salinfo._ackcmd_writer.put()
+
+    def ackInProgress(self, data, result=""):
+        """Deprecated version of ack_in_progress."""
+        # TODO DM-26518: remove this method
+        warnings.warn(
+            "ackInProgress is deprecated; use ack_in_progress and specify timeout instead",
+            DeprecationWarning,
+        )
+        self.ack_in_progress(data=data, result=result, timeout=0)
 
     def ack_in_progress(self, data, *, timeout, result=""):
         """Ackowledge this command as "in progress".

--- a/python/lsst/ts/salobj/topics/read_topic.py
+++ b/python/lsst/ts/salobj/topics/read_topic.py
@@ -366,7 +366,7 @@ class ReadTopic(BaseTopic):
             raise TypeError(f"func={func} not callable")
         self._data_queue.clear()
         self._callback = func
-        self._callback_loop_task = asyncio.ensure_future(self._callback_loop())
+        self._callback_loop_task = asyncio.create_task(self._callback_loop())
 
     @property
     def has_callback(self):
@@ -562,7 +562,7 @@ class ReadTopic(BaseTopic):
                 self._callback_tasks = {
                     task for task in self._callback_tasks if not task.done()
                 }
-                self._callback_tasks.add(asyncio.ensure_future(result))
+                self._callback_tasks.add(asyncio.create_task(result))
             else:
                 await result
 

--- a/python/lsst/ts/salobj/topics/remote_command.py
+++ b/python/lsst/ts/salobj/topics/remote_command.py
@@ -177,7 +177,7 @@ class _CommandInfo:
         if timeout is None:  # For backwards compatibility.
             timeout = DEFAULT_TIMEOUT
         try:
-            self._wait_task = asyncio.ensure_future(
+            self._wait_task = asyncio.create_task(
                 self._basic_next_ackcmd(timeout=timeout)
             )
             ackcmd = await self._wait_task

--- a/tests/data/topic_writer.py
+++ b/tests/data/topic_writer.py
@@ -44,6 +44,8 @@ class TopicWriter(salobj.BaseCsc):
         SAL index.
     """
 
+    valid_simulation_modes = [0]
+
     def __init__(self, index):
         print(f"TopicWriter: starting with index={index}")
         super().__init__(name="Test", index=index)

--- a/tests/test_sal_info.py
+++ b/tests/test_sal_info.py
@@ -192,6 +192,10 @@ class SalInfoTestCase(asynctest.TestCase):
             self.assertEqual(ackcmd.error, 0)
             self.assertEqual(ackcmd.result, "")
 
+            with self.assertWarns(DeprecationWarning):
+                ackcmd2 = salinfo.makeAckCmd(private_seqNum=seqNum, ack=ack)
+            self.assertEqual(ackcmd.get_vars(), ackcmd2.get_vars())
+
             # Specify an error code and result
             for truncate_result in (False, True):
                 with self.subTest(truncate_result=truncate_result):
@@ -210,6 +214,16 @@ class SalInfoTestCase(asynctest.TestCase):
                     self.assertEqual(ackcmd.ack, ack)
                     self.assertEqual(ackcmd.error, error)
                     self.assertEqual(ackcmd.result, result)
+
+                    with self.assertWarns(DeprecationWarning):
+                        ackcmd2 = salinfo.makeAckCmd(
+                            private_seqNum=seqNum,
+                            ack=ack,
+                            error=error,
+                            result=result,
+                            truncate_result=truncate_result,
+                        )
+                    self.assertEqual(ackcmd.get_vars(), ackcmd2.get_vars())
 
             # Test behavior with too-long result strings
             seqNum = 27


### PR DESCRIPTION
And restore deprecated SalInfo.makeAckCmd and topics.ControllerCommand.ackInProgress.