### PR TITLE
DM-28984: Update tests for warnings to specify a string

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -11,11 +11,11 @@ v6.3.0
 
 Deprecations:
 
-* Deprecated `BaseCsc.set_simulation_mode`. Note that `BaseCsc.implement_simulation_mode`,
+* Deprecate `BaseCsc.set_simulation_mode`. Note that `BaseCsc.implement_simulation_mode`,
   and allowing ``valid_simulation_modes = None`` have both been deprecated for some time.
   Please move all simulation mode handling to the constructor (if synchronous) or `BaseCsc.start` (if not).
-* Deprecated omitting the ``version`` class attribute of CSCs.
-* Deprecated `ConfigurableCsc` constructor argument ``schema_path``; please specify ``config_schema`` instead.
+* Deprecate omitting the ``version`` class attribute of CSCs.
+* Deprecate `ConfigurableCsc` constructor argument ``schema_path``; please specify ``config_schema`` instead.
 
 Changes:
 
@@ -34,6 +34,8 @@ Changes:
   which simplifies packaging and distribution.
 * `BaseConfigTestCase`: added argument ``schema_name`` to ``check_standard_config_files``
   and made ``sal_name`` optional.
+* Update test for warnings to include testing for the correct message.
+  This makes sure the correct warning is seen (or not seen).
 
 Requirements:
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -214,7 +214,9 @@ class BasicsTestCase(asynctest.TestCase):
         alias for set_random_lsst_dds_partition_prefix.
         """
         old_prefix = os.environ["LSST_DDS_PARTITION_PREFIX"]
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarnsRegex(
+            DeprecationWarning, "Use set_random_lsst_dds_partition_prefix"
+        ):
             salobj.set_random_lsst_dds_domain()
         new_prefix = os.environ["LSST_DDS_PARTITION_PREFIX"]
         self.assertNotEqual(old_prefix, new_prefix)

--- a/tests/test_csc_constructor.py
+++ b/tests/test_csc_constructor.py
@@ -86,7 +86,9 @@ class TestCscConstructorTestCase(asynctest.TestCase):
             self.assertEqual(csc.summary_state, initial_state)
 
     async def test_deprecated_schema_path_arg(self):
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarnsRegex(
+            DeprecationWarning, "schema_path argument is deprecated"
+        ):
             expected_schema = salobj.CONFIG_SCHEMA
             schema_path = (
                 pathlib.Path(__file__).resolve().parents[1] / "schema" / "Test.yaml"
@@ -165,19 +167,22 @@ class TestCscConstructorTestCase(asynctest.TestCase):
                 pass
 
         mv = None
+        # Expected fragment of warning message.
+        message_regex = r"set class attribute .*version"
         try:
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarnsRegex(DeprecationWarning, message_regex):
                 mv = MissingVersionCsc(index=next(index_gen))
         finally:
             if mv is not None:
                 await mv.close()
 
         # Adding the version attribute should eliminate the warning
+        # in question.
         MissingVersionCsc.version = "foo"
         mv = None
         try:
             with self.assertRaises(AssertionError):
-                with self.assertWarns(DeprecationWarning):
+                with self.assertWarnsRegex(DeprecationWarning, message_regex):
                     mv = MissingVersionCsc(index=next(index_gen))
         finally:
             if mv is not None:

--- a/tests/test_csc_simulation_mode.py
+++ b/tests/test_csc_simulation_mode.py
@@ -203,7 +203,8 @@ class SimulationModeTestCase(asynctest.TestCase):
 
         for bad_simulation_mode in (1, 2):
             index = next(index_gen)
-            with self.assertWarns(DeprecationWarning):
+            warning_regex = "valid_simulation_modes=None is deprecated"
+            with self.assertWarnsRegex(DeprecationWarning, warning_regex):
                 csc = TestCscWithDeprecatedSimulation(
                     index=index, simulation_mode=bad_simulation_mode
                 )
@@ -212,7 +213,7 @@ class SimulationModeTestCase(asynctest.TestCase):
 
         # Test the one valid simulation mode
         index = next(index_gen)
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarnsRegex(DeprecationWarning, warning_regex):
             csc = TestCscWithDeprecatedSimulation(index=index, simulation_mode=0)
         try:
             await csc.start_task

--- a/tests/test_sal_info.py
+++ b/tests/test_sal_info.py
@@ -186,7 +186,9 @@ class SalInfoTestCase(asynctest.TestCase):
             os.environ["LSST_DDS_PARTITION_PREFIX"] + "Extra text"
         )
         async with salobj.Domain() as domain:
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarnsRegex(
+                DeprecationWarning, "LSST_DDS_PARTITION_PREFIX instead of deprecated",
+            ):
                 salinfo = salobj.SalInfo(domain=domain, name="Test", index=1)
             self.assertEqual(
                 salinfo.partition_prefix, os.environ["LSST_DDS_PARTITION_PREFIX"]
@@ -196,7 +198,10 @@ class SalInfoTestCase(asynctest.TestCase):
         # if LSST_DDS_PARTITION_PREFIX is not defined.
         os.environ["LSST_DDS_DOMAIN"] = os.environ.pop("LSST_DDS_PARTITION_PREFIX")
         async with salobj.Domain() as domain:
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                "LSST_DDS_PARTITION_PREFIX not defined; using deprecated fallback",
+            ):
                 salinfo = salobj.SalInfo(domain=domain, name="Test", index=1)
             self.assertEqual(salinfo.partition_prefix, os.environ["LSST_DDS_DOMAIN"])
 
@@ -246,7 +251,8 @@ class SalInfoTestCase(asynctest.TestCase):
             self.assertEqual(ackcmd.error, 0)
             self.assertEqual(ackcmd.result, "")
 
-            with self.assertWarns(DeprecationWarning):
+            warning_regex = "makeAckCmd is deprecated"
+            with self.assertWarnsRegex(DeprecationWarning, warning_regex):
                 ackcmd2 = salinfo.makeAckCmd(private_seqNum=seqNum, ack=ack)
             self.assertEqual(ackcmd.get_vars(), ackcmd2.get_vars())
 
@@ -269,7 +275,7 @@ class SalInfoTestCase(asynctest.TestCase):
                     self.assertEqual(ackcmd.error, error)
                     self.assertEqual(ackcmd.result, result)
 
-                    with self.assertWarns(DeprecationWarning):
+                    with self.assertWarnsRegex(DeprecationWarning, warning_regex):
                         ackcmd2 = salinfo.makeAckCmd(
                             private_seqNum=seqNum,
                             ack=ack,

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -593,13 +593,18 @@ class TopicsTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
                 self.assertEqual(read_topic.nqueued, num_commands)
 
                 # get with flush=False should warn and not flush the queue
-                with self.assertWarns(DeprecationWarning):
+                with self.assertWarnsRegex(
+                    DeprecationWarning,
+                    "Specifying a value for the flush argument is deprecated",
+                ):
                     data = read_topic.get(flush=False)
                 self.assertEqual(read_topic.nqueued, num_commands)
                 self.csc.assert_scalars_equal(cmd_data_list[-1], data)
 
                 # get with flush=True should warn and flush the queue
-                with self.assertWarns(DeprecationWarning):
+                with self.assertWarnsRegex(
+                    DeprecationWarning, "flush=True is deprecated"
+                ):
                     data = read_topic.get(flush=True)
                 self.assertEqual(read_topic.nqueued, 0)
                 self.csc.assert_scalars_equal(cmd_data_list[-1], data)
@@ -1214,7 +1219,9 @@ class TopicsTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
                 dds_history_depth + 1,
                 dds_durability_history_depth + 1,
             ):
-                with self.assertWarns(UserWarning):
+                with self.assertWarnsRegex(
+                    UserWarning, "max_history=.* > history depth"
+                ):
                     salobj.topics.ReadTopic(
                         salinfo=salinfo,
                         name="scalars",


### PR DESCRIPTION
This makes sure the correct warning is seen (or not seen, in one case).