### PR TITLE
Fix test_sal_info for deleted generic topics

### DIFF
--- a/python/lsst/ts/salobj/controller.py
+++ b/python/lsst/ts/salobj/controller.py
@@ -160,8 +160,8 @@ class Controller:
 
     * Events, each an instance of `topics.ControllerEvent`:
 
-        * ``evt_appliedSettingsMatchStart``
-        * ``evt_errorCode``
+        * ``evt_authList``
+        * ``evt_configurationApplied``
         * ... and so on for all other standard CSC events
         * ``evt_arrays``
         * ``evt_scalars``

--- a/python/lsst/ts/salobj/remote.py
+++ b/python/lsst/ts/salobj/remote.py
@@ -121,8 +121,8 @@ class Remote:
 
     * Events, each an instance of `topics.RemoteEvent`:
 
-        * ``evt_appliedSettingsMatchStart``
-        * ``evt_errorCode``
+        * ``evt_authList``
+        * ``evt_configurationApplied``
         * ... and so on for all other standard CSC log events
         * ``evt_arrays``
         * ``evt_scalars``

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -100,7 +100,7 @@ class RemoteTestCase(unittest.IsolatedAsyncioTestCase):
             )
 
             # remote2 uses the exclude argument
-            exclude = ["appliedSettingsMatchStart", "arrays"]
+            exclude = ["errorCode", "arrays"]
             remote2 = salobj.Remote(
                 domain=domain, name="Test", index=index, exclude=exclude
             )

--- a/tests/test_sal_info.py
+++ b/tests/test_sal_info.py
@@ -96,40 +96,42 @@ class SalInfoTestCase(unittest.IsolatedAsyncioTestCase):
 
             assert salinfo.name_index == f"Test:{index}"
 
-            # expected_commands omits a few commands that TestCsc
-            # does not support, but that are in generics.
-            expected_commands = [
+            # Expected commands; must be complete and sorted alphabetically.
+            expected_commands = (
                 "disable",
                 "enable",
                 "exitControl",
-                "standby",
-                "start",
+                "fault",
                 "setArrays",
+                "setAuthList",
                 "setLogLevel",
                 "setScalars",
-                "fault",
+                "standby",
+                "start",
                 "wait",
-            ]
-            assert set(expected_commands).issubset(set(salinfo.command_names))
+            )
+            assert expected_commands == salinfo.command_names
 
-            # expected_events omits a few events that TestCsc
-            # does not support, but that are in generics.
-            expected_events = [
+            # Expected events; must be complete and sorted alphabetically.
+            expected_events = (
+                "arrays",
+                "authList",
+                "configurationApplied",
+                "configurationsAvailable",
                 "errorCode",
                 "heartbeat",
                 "logLevel",
                 "logMessage",
-                "settingVersions",
-                "simulationMode",
-                "summaryState",
                 "scalars",
-                "arrays",
-            ]
-            assert set(expected_events).issubset(set(salinfo.event_names))
+                "simulationMode",
+                "softwareVersions",
+                "summaryState",
+            )
+            assert expected_events == salinfo.event_names
 
             # telemetry topic names should match; there are no generics
-            expected_telemetry = ["arrays", "scalars"]
-            assert set(expected_telemetry) == set(salinfo.telemetry_names)
+            expected_telemetry = ("arrays", "scalars")
+            assert expected_telemetry == salinfo.telemetry_names
 
             expected_sal_topic_names = ["ackcmd"]
             expected_sal_topic_names += [


### PR DESCRIPTION
and make the test pickier now that CSCs only get
the commands that they explicitly ask for.