### PR TITLE
DM-34038: ConfigurableCsc: fix config overrides for hierarchical schema

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -40,6 +40,8 @@ v7.0.0
   * Delete ``assert_black_formatted`` and ``tests/test_black.py``; use pytest-black instead.
   * `IdlMetadata`: eliminate the ``str_length`` field (RFC-827).
   * Modify `topics.BaseTopic`, `topics.ReadTopic`, and `topics.WriteTopic`: use constructor argument ``attr_name`` instead of ``name`` and ``sal_prefix``.
+  * `BaseConfigTestCase`: delete the ``get_module_dir`` method.
+    It is no longer useful and was unsafe.
 
 * Eliminate the following deprecated features:
 
@@ -77,6 +79,8 @@ v7.0.0
         * ``utc_from_tai_unix``
 
 * Enhance `CscCommander.make_from_cmd_line` to support index = an IntEnum subclass.
+* Fix the OpenSplice version reported in the ``softwareVersions`` event.
+  Report the value of environment variable ``OSPL_RELEASE`` instead of the version of the ``dds`` library.
 * Update ``Jenkinsfile`` to checkout ts_config_ocs.
 
 Requirements:

--- a/python/lsst/ts/salobj/__init__.py
+++ b/python/lsst/ts/salobj/__init__.py
@@ -24,6 +24,7 @@ from .controller import *
 from .remote import *
 from .base_script import *
 from .csc_utils import *
+from .hierarchical_update import *
 from .testutils import *
 from .config_schema import *
 from .testcsc import *

--- a/python/lsst/ts/salobj/base_config_test_case.py
+++ b/python/lsst/ts/salobj/base_config_test_case.py
@@ -45,28 +45,6 @@ class BaseConfigTestCase(metaclass=abc.ABCMeta):
       `check_config_files`.
     """
 
-    def get_module_dir(self, module_name: str) -> pathlib.Path:
-        """Get the directory of a python module, by importing the module.
-
-        Parameters
-        ----------
-        module_name : `str`
-            Module name, e.g. "lsst.ts.salobj".
-
-        Returns
-        -------
-        module_dir : `pathlib.Path`
-            Module directory, e.g. ``<package_root>/lsst/ts/salobj``
-
-        Raises
-        ------
-        ModuleNotFoundError
-            If the module is not found.
-        """
-        module = importlib.import_module(module_name)
-        init_path = pathlib.Path(module.__file__)
-        return init_path.parent
-
     def get_schema(
         self,
         csc_package_root: type_hints.PathType,

--- a/python/lsst/ts/salobj/base_csc.py
+++ b/python/lsst/ts/salobj/base_csc.py
@@ -795,12 +795,12 @@ class BaseCsc(Controller):
             await getattr(self, f"begin_{cmd_name}")(data)
         except base.ExpectedError as e:
             self.log.error(
-                f"beg_{cmd_name} failed; remaining in state {curr_state!r}: {e}"
+                f"begin_{cmd_name} failed; remaining in state {curr_state!r}: {e}"
             )
             raise
         except Exception:
             self.log.exception(
-                f"beg_{cmd_name} failed; remaining in state {curr_state!r}"
+                f"begin_{cmd_name} failed; remaining in state {curr_state!r}"
             )
             raise
         self._summary_state = new_state
@@ -808,7 +808,7 @@ class BaseCsc(Controller):
             await getattr(self, f"end_{cmd_name}")(data)
         except base.ExpectedError as e:
             self.log.error(
-                f"beg_{cmd_name} failed; reverting to state {curr_state!r}: {e}"
+                f"begin_{cmd_name} failed; reverting to state {curr_state!r}: {e}"
             )
             raise
         except Exception:

--- a/python/lsst/ts/salobj/base_csc.py
+++ b/python/lsst/ts/salobj/base_csc.py
@@ -26,12 +26,12 @@ __all__ = ["BaseCsc"]
 import argparse
 import asyncio
 import enum
+import os
 import sys
 import typing
 
 from lsst.ts import utils
 from . import base
-from . import dds_utils
 from . import type_hints
 from .sal_enums import State
 from .controller import Controller
@@ -195,7 +195,7 @@ class BaseCsc(Controller):
         self.evt_softwareVersions.set(  # type: ignore
             salVersion=format_version(self.salinfo.metadata.sal_version),
             xmlVersion=format_version(self.salinfo.metadata.xml_version),
-            openSpliceVersion=dds_utils.get_dds_version(),
+            openSpliceVersion=os.environ.get("OSPL_RELEASE", "?"),
             cscVersion=getattr(self, "version", "?"),
         )
 

--- a/python/lsst/ts/salobj/configurable_csc.py
+++ b/python/lsst/ts/salobj/configurable_csc.py
@@ -36,6 +36,7 @@ from lsst.ts import utils
 from . import base
 from . import type_hints
 from .base_csc import BaseCsc, State
+from .hierarchical_update import hierarchical_update
 from .validator import StandardValidator
 
 
@@ -244,7 +245,7 @@ class ConfigurableCsc(BaseCsc, abc.ABC):
             cannot be parsed as yaml dicts, or produce an invalid configuration
             (one that does not match the schema).
         """
-        config_dict = {}
+        config_dict: typing.Dict[str, typing.Any] = {}
         for filename in files_to_read:
             if not filename:
                 continue
@@ -273,7 +274,12 @@ class ConfigurableCsc(BaseCsc, abc.ABC):
                     f"Could not parse data in {filepath} as a dict: {e!r}"
                 )
             if config_data is not None:
-                config_dict.update(config_data)
+                hierarchical_update(
+                    main=config_dict,
+                    override=config_data,
+                    main_name="config",
+                    override_name=filename,
+                )
 
         # Delete metadata, if present (it is not part of the schema)
         if config_dict:

--- a/python/lsst/ts/salobj/dds_utils.py
+++ b/python/lsst/ts/salobj/dds_utils.py
@@ -33,6 +33,10 @@ def get_dds_version(dds_file: typing.Optional[str] = None) -> str:
 
     If it cannot be determined, return "?".
 
+    Note: do not use this function to determine the OpenSplice version
+    for the softwareVersions event. Use the value of environment variable
+    OSPL_RELEASE for that.
+
     Parameters
     ----------
     dds_file : `str` or `None`, optional

--- a/python/lsst/ts/salobj/hierarchical_update.py
+++ b/python/lsst/ts/salobj/hierarchical_update.py
@@ -1,0 +1,88 @@
+# This file is part of ts_salobj.
+#
+# Developed for the Rubin Observatory Telescope and Site System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["hierarchical_update"]
+
+import typing
+
+
+def hierarchical_update(
+    main: typing.Dict[str, typing.Any],
+    override: typing.Dict[str, typing.Any],
+    main_name: str,
+    override_name: str,
+    prefix: str = "",
+) -> None:
+    """Hierarchically update one dict with values from another.
+
+    If a value in ``override`` is a dict, then work item by item,
+    recursively.
+
+    Parameters
+    ----------
+    main : `dict`
+        Dict to update.
+    override : `dict`
+        Dict of update values.
+    main_name : `str`
+        Name of main dict; used for error messages.
+    override_name : `str`
+        Name of override dict; used for error messages.
+    prefix : `str`
+        The key prefix for error messages.
+        Should be blank for the first call
+        and be "[key][subkey]...[sub...subkey]" for each successive key.
+
+    Raise
+    -----
+     ValueError
+        If a value exists in both dicts but is a dict in one
+        and not in the other.
+    """
+    for arg, argname in ((main, main_name), (override, override_name)):
+        if not isinstance(arg, dict):
+            raise ValueError(f"{argname}{prefix}={arg!r} is not a dict")
+
+    for key, override_value in override.items():
+        if key in main:
+            if isinstance(override_value, dict):
+                # Recursively override dict values with dict values.
+                # Note: hierarchical_update tests that main[key] is a dict
+                # so there is no need to do that here.
+                hierarchical_update(
+                    main=main[key],
+                    override=override_value,
+                    main_name=main_name,
+                    override_name=override_name,
+                    prefix=f"{prefix}[{key}]",
+                )
+            else:
+                main_value = main[key]
+                if isinstance(main_value, dict):
+                    raise ValueError(
+                        f"{main_name}{prefix}[{key}]={main_value} is a dict, "
+                        f"but {override_name}{prefix}[{key}] = {override_value!r} is not"
+                    )
+                # Replace non-dict with non-dict
+                main[key] = override_value
+        else:
+            # Add override_value to main
+            main[key] = override_value

--- a/python/lsst/ts/salobj/testcsccommander.py
+++ b/python/lsst/ts/salobj/testcsccommander.py
@@ -101,13 +101,13 @@ class TestCscCommander(csc_commander.CscCommander):
             if field not in self.array_field_types:
                 raise RuntimeError(f"Unknown field {field}")
             field_type = self.array_field_types[field]
-            vals = [field_type(val) for val in valstr.split(",")]
+            vals = [field_type(val) for val in valstr.split(",")]  # type: ignore
             if len(vals) > ARR_LEN:
                 raise RuntimeError(
                     f"Field {field} has more than {ARR_LEN} values: {vals}"
                 )
             elif len(vals) < ARR_LEN:
                 n_to_append = ARR_LEN - len(vals)
-                vals += [field_type("0")] * n_to_append
+                vals += [field_type("0")] * n_to_append  # type: ignore
             kwargs[field] = vals
         await self.remote.cmd_setArrays.set_start(**kwargs)  # type: ignore

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -60,13 +60,6 @@ class ConfigTestCase(salobj.BaseConfigTestCase, unittest.TestCase):
             # Must specify sal_name or schema_subpath
             self.get_schema(csc_package_root=csc_package_root)
 
-    def test_get_module_dir(self) -> None:
-        module_dir = self.get_module_dir("lsst.ts.salobj")
-        assert str(module_dir).endswith("lsst/ts/salobj")
-
-        with pytest.raises(ModuleNotFoundError):
-            self.get_module_dir("lsst.lsst.lsst.no_such_module")
-
     @unittest.skipIf("TS_CONFIG_OCS_DIR" not in os.environ, "ts_config_ocs not found")
     def test_standard_configs(self) -> None:
         """Test the config files in ts_config_ocs/Test/..."""

--- a/tests/test_csc_configuration.py
+++ b/tests/test_csc_configuration.py
@@ -86,7 +86,7 @@ class ConfigurationTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTest
                 topic=self.remote.evt_softwareVersions,
                 xmlVersion=metadata.xml_version,
                 salVersion=metadata.sal_version,
-                openSpliceVersion=salobj.get_dds_version(),
+                openSpliceVersion=os.environ.get("OSPL_RELEASE", "?"),
                 cscVersion=salobj.__version__,
             )
             await self.assert_next_sample(

--- a/tests/test_csc_utils.py
+++ b/tests/test_csc_utils.py
@@ -118,13 +118,8 @@ class SetSummaryStateTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTe
             assert states[0] == initial_state
             assert states[-1] == final_state
             assert self.csc.summary_state == final_state
-            if (
-                initial_state
-                in (
-                    salobj.State.FAULT,
-                    salobj.State.STANDBY,
-                )
-                and final_state in (salobj.State.DISABLED, salobj.State.ENABLED)
+            if (initial_state in (salobj.State.FAULT, salobj.State.STANDBY)) and (
+                final_state in (salobj.State.DISABLED, salobj.State.ENABLED)
             ):
                 # The start command was sent, so check that the configuration
                 # is as specified to the set_summary_state function.

--- a/tests/test_hierarchical_update.py
+++ b/tests/test_hierarchical_update.py
@@ -1,0 +1,139 @@
+# This file is part of ts_salobj.
+#
+# Developed for the Rubin Observatory Telescope and Site System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import copy
+import unittest
+
+import pytest
+
+from lsst.ts import salobj
+
+
+class HierarchicalTestCase(unittest.IsolatedAsyncioTestCase):
+    def test_basics(self) -> None:
+        dict1 = dict(
+            key1="dict1 value1",
+            hierkey1=dict(
+                key11="dict1 value11",
+                hierkey11=dict(
+                    key111="dict1 value111",
+                ),
+            ),
+            hierkey2=dict(
+                key12="dict1 value12",
+                hierkey12=dict(
+                    key122="dict1 value122",
+                ),
+            ),
+        )
+        dict2 = dict(
+            key1="dict2 value1",
+            key2="dict2 value2",
+            hierkey1=dict(
+                key11="dict2 value11",
+                hierkey11=dict(
+                    key111="dict2 value111",
+                ),
+            ),
+            hierkey3=dict(
+                key13="dict2 value13",
+                hierkey13=dict(
+                    key113="dict2 value113",
+                ),
+            ),
+        )
+
+        # Overriding a dict with itself should produce no changes
+        dict1copy = copy.deepcopy(dict1)
+        salobj.hierarchical_update(
+            main=dict1copy, override=dict1, main_name="main", override_name="override"
+        )
+        assert dict1copy == dict1
+
+        dict2copy = copy.deepcopy(dict2)
+        salobj.hierarchical_update(
+            main=dict2copy, override=dict2, main_name="main", override_name="override"
+        )
+        assert dict2copy == dict2
+
+        dict1copy = copy.deepcopy(dict1)
+        salobj.hierarchical_update(
+            main=dict1copy, override=dict2, main_name="dict1", override_name="dict2"
+        )
+        assert dict1copy == dict(
+            key1="dict2 value1",
+            key2="dict2 value2",
+            hierkey1=dict(
+                key11="dict2 value11",
+                hierkey11=dict(
+                    key111="dict2 value111",
+                ),
+            ),
+            hierkey2=dict(
+                key12="dict1 value12",
+                hierkey12=dict(
+                    key122="dict1 value122",
+                ),
+            ),
+            hierkey3=dict(
+                key13="dict2 value13",
+                hierkey13=dict(
+                    key113="dict2 value113",
+                ),
+            ),
+        )
+
+    def test_errors(self) -> None:
+        dict1 = dict(
+            key1="dict1 value1",
+            hierkey1=dict(
+                key11="dict1 value11",
+                hierkey11=dict(
+                    key111="dict1 value111",
+                ),
+            ),
+            hierkey2=dict(
+                key12="dict1 value12",
+                hierkey12=dict(
+                    key122="dict1 value122",
+                ),
+            ),
+        )
+        for bad_dict, errmsg_re in (
+            (
+                dict(
+                    key1=dict(key11="a dict instead of a scalar or array"),
+                ),
+                r"dict1\[key1\].+is not a dict",
+            ),
+            (
+                dict(hierkey1="a scalar instead of a dict"),
+                r"dict1\[hierkey1\].+is a dict.+bad_dict\[hierkey1\].+is not",
+            ),
+        ):
+            dict1copy = copy.deepcopy(dict1)
+            with pytest.raises(ValueError, match=errmsg_re):
+                salobj.hierarchical_update(
+                    main=dict1copy,
+                    override=bad_dict,
+                    main_name="dict1",
+                    override_name="bad_dict",
+                )


### PR DESCRIPTION
Add a hierarchical_update function and use it in ConfigurableCsc.
Also work around a few mypy complaints when using the latest mypy
and tweak formatting in one bit of code to be compatible with black 20.8b1 and 22.1.0.