### PR TITLE
DM-39753 kafka: add MockWriteTopic and make_mock_write_topics

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -45,6 +45,11 @@ v7.4.0
 
   Note that existing subclasses need not change anything to get the new behavior.
   You may add optional constructor argument ``check_if_duplicate`` if you like, but it is not very useful.
+* Added `topics.MockWriteTopic` and `make_mock_write_topics`.
+  These are used to test writers (such as ESS data clients) without actually writing data to SAL.
+* `topics.SetWriteResult`: change to a dataclass.
+* `topics.WriteTopic`: change ``default_force_output`` from a class variable to an instance variable computed in the constructor.
+  This simplifies subclassing and makes `topics.MockWriteTopic` practical.
 
 v7.3.4
 ------

--- a/python/lsst/ts/salobj/__init__.py
+++ b/python/lsst/ts/salobj/__init__.py
@@ -25,6 +25,7 @@ from .field_info import *
 from .get_component_info import *
 from .get_enums_from_xml import *
 from .hierarchical_update import *
+from .make_mock_write_topics import *
 from .remote import *
 from .sal_enums import *
 from .sal_info import *

--- a/python/lsst/ts/salobj/make_mock_write_topics.py
+++ b/python/lsst/ts/salobj/make_mock_write_topics.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+# This file is part of ts_salobj.
+#
+# Developed for the Rubin Observatory Telescope and Site System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["make_mock_write_topics"]
+
+import contextlib
+import types
+from collections.abc import AsyncGenerator
+
+from .domain import Domain
+from .sal_info import SalInfo
+from .topics import MockWriteTopic
+
+
+@contextlib.asynccontextmanager
+async def make_mock_write_topics(
+    name: str,
+    attr_names: list[str],
+    index: int | None = None,
+) -> AsyncGenerator[types.SimpleNamespace, None]:
+    """Make a struct of mock write topics for unit testing data clients.
+
+    The struct attribute names are the topic attr_names, and the values
+    are instances of `topics.MockWriteTopic`.
+
+    Parameters
+    ----------
+    name : `str`
+        SAL component name.
+    attr_names : `list` [`str`]
+        List of topic attribute names, e.g.
+        ["tel_temperature", "evt_lightningStrike"]
+    index : `int` | `None`, optional
+        The SAL index. Irrelevant unless you want to check the salIndex
+        field of the data. None results in 0 for a non-indexed
+        compoonent and 1 for an indexed component.
+    """
+    if not attr_names:
+        raise ValueError("You must provide one or more topic attr_names")
+
+    async with Domain() as domain, SalInfo(
+        domain=domain, name=name, index=index
+    ) as salinfo:
+        if index is None:
+            index = 1 if salinfo.indexed else 0
+        topics_dict = {
+            attr_name: MockWriteTopic(salinfo=salinfo, attr_name=attr_name)
+            for attr_name in attr_names
+        }
+        yield types.SimpleNamespace(**topics_dict)

--- a/python/lsst/ts/salobj/topics/__init__.py
+++ b/python/lsst/ts/salobj/topics/__init__.py
@@ -2,6 +2,7 @@ from .base_topic import *
 from .controller_command import *
 from .controller_event import *
 from .controller_telemetry import *
+from .mock_write_topic import *
 from .read_topic import *
 from .remote_command import *
 from .remote_event import *

--- a/python/lsst/ts/salobj/topics/controller_event.py
+++ b/python/lsst/ts/salobj/topics/controller_event.py
@@ -42,7 +42,5 @@ class ControllerEvent(write_topic.WriteTopic):
         Event name with no prefix, e.g. "summaryState".
     """
 
-    default_force_output = False
-
     def __init__(self, salinfo: SalInfo, name: str) -> None:
         super().__init__(salinfo=salinfo, attr_name="evt_" + name)

--- a/python/lsst/ts/salobj/topics/mock_write_topic.py
+++ b/python/lsst/ts/salobj/topics/mock_write_topic.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+# This file is part of ts_salobj.
+#
+# Developed for the Rubin Observatory Telescope and Site System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["MockWriteTopic"]
+
+import typing
+
+from .. import type_hints
+from .write_topic import MAX_SEQ_NUM, WriteTopic
+
+if typing.TYPE_CHECKING:
+    from ..sal_info import SalInfo
+
+
+class MockWriteTopic(WriteTopic):
+    """A version of WriteTopic that records every message written
+    instead of actually writing it.
+
+    It is easiest to construct these by calling `make_mock_write_topics`.
+    MockWriteTopic is only intended for unit tests and related short-term use;
+    it saves every message, so long term use will leak memory.
+
+    Parameters
+    ----------
+    salinfo : `SalInfo`
+        SAL component information
+    attr_name : `str`
+        Topic name with attribute prefix. The prefix must be one of:
+        ``cmd_``, ``evt_``, ``tel_``, or (only for the ackcmd topic) ``ack_``.
+    min_seq_num : `int` or `None`, optional
+        Minimum value for the ``private_seqNum`` field. The default is 1.
+        If `None` then ``private_seqNum`` is not set; this is needed
+        for the ackcmd writer, which sets the field itself.
+    max_seq_num : `int`, optional
+        Maximum value for ``private_seqNum``, inclusive.
+        The default is the maximum allowed positive value
+        (``private_seqNum`` is a 4-byte signed int).
+        Ignored if ``min_seq_num`` is `None`.
+    initial_seq_num : `int`, optional
+        Initial sequence number; if `None` use min_seq_num.
+
+    Attributes
+    ----------
+    data_list : `list` [`type_hints.BaseMsgType`]
+        List of data written, with newer data at the end.
+    Plus the attributes of:
+       `WriteTopic`
+    """
+
+    def __init__(
+        self,
+        *,
+        salinfo: SalInfo,
+        attr_name: str,
+        min_seq_num: int | None = 1,
+        max_seq_num: int = MAX_SEQ_NUM,
+        initial_seq_num: int | None = None,
+    ) -> None:
+        super().__init__(
+            salinfo=salinfo,
+            attr_name=attr_name,
+            min_seq_num=min_seq_num,
+            max_seq_num=max_seq_num,
+            initial_seq_num=initial_seq_num,
+        )
+        self.data_list: list[type_hints.BaseMsgType] = []
+
+    async def write(self) -> type_hints.BaseMsgType:
+        """Write the current data and return a copy of the data written.
+
+        Returns
+        -------
+        data : self.DataType
+            The data that was written.
+            This can be useful to avoid race conditions
+            (as found in RemoteCommand).
+
+        Raises
+        ------
+        RuntimeError
+            If not running.
+        """
+        data = self._prepare_data_to_write()
+        self.data_list.append(data)
+        return data

--- a/python/lsst/ts/salobj/topics/write_topic.py
+++ b/python/lsst/ts/salobj/topics/write_topic.py
@@ -97,9 +97,11 @@ class WriteTopic(BaseTopic):
     ----------
     isopen : `bool`
         Is this instance open? `True` until `close` or `basic_close` is called.
+    default_force_output : `bool`
+        Default value for the force_output argument of write.
+    Plus the attributes of:
+       `BaseTopic`
     """
-    # Default value for the force_output argument of write
-    default_force_output = True
 
     def __init__(
         self,
@@ -111,6 +113,9 @@ class WriteTopic(BaseTopic):
         initial_seq_num: int | None = None,
     ) -> None:
         super().__init__(salinfo=salinfo, attr_name=attr_name)
+        # Events are usually only written if data has changed.
+        # Commands, telemetry and ackcmd topics are usually always written.
+        self.default_force_output = not attr_name.startswith("evt_")
         self.isopen = True
         self.min_seq_num = min_seq_num  # record for unit tests
         self.max_seq_num = max_seq_num


### PR DESCRIPTION
This is very similar to the DDS version, but MockWriteTopic needs to override a different method.