### PR TITLE
fix PySide6 compatibility

### DIFF
--- a/python/lsst/ts/salobj/sal_info.py
+++ b/python/lsst/ts/salobj/sal_info.py
@@ -667,7 +667,7 @@ class SalInfo:
             # Create Kafka topics, serializers, and deserializers.
             # Set self._serializers_and_contexts and
             # self._deserializers_and_contexts.
-            await self.loop.run_in_executor(self.pool, func=self._blocking_setup_kafka)
+            await self.loop.run_in_executor(self.pool, self._blocking_setup_kafka)
 
             if not self._read_topics:
                 # There are no read topics, so self.start_task has to be


### PR DESCRIPTION
Due to incompatibilities of different AsyncIO implementation, it's
better to call run_in_loop without specifying func argument by name.
