### PR TITLE
tickets/DM-45216

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -9,6 +9,13 @@ Version History
 
 .. Version 8 of salobj will contain the kafka release.
 
+v7.7.1
+------
+
+* Added ``WildcardIndexError`` to handle wildcard indices in SAL components,
+  ensuring backward compatibility.
+
+
 v7.7.0
 ------
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -28,6 +28,7 @@ import unittest
 
 import pytest
 from lsst.ts import salobj, utils
+from lsst.ts.salobj import WildcardIndexError
 
 index_gen = utils.index_generator()
 
@@ -189,7 +190,13 @@ class BasicsTestCase(unittest.IsolatedAsyncioTestCase):
             ("Script:15 "),  # trailing space
             ("Script:"),  # colon with no index
             ("Script:zero"),  # index is not an integer
+            ("Script:*"),  # Wildcard index
         ):
             with self.subTest(bad_name=bad_name):
                 with pytest.raises(ValueError):
                     salobj.name_to_name_index(bad_name)
+
+        # Invalid case for WildcardIndexError
+        with self.subTest(bad_name="Script:*"):
+            with pytest.raises(WildcardIndexError):
+                salobj.name_to_name_index("Script:*")


### PR DESCRIPTION

This PR introduces a new `WildcardIndexError` exception to handle wildcard indices (`*`) in SAL component names. This is particularly useful in cases where an index in a component name (e.g., `Test:*`) is a wildcard, allowing operations to be applied to all indices of a given CSC.

Key changes:
- Added `WildcardIndexError` to handle wildcard indices in SAL components, ensuring backward compatibility.
- Applied this in `ts_standardscripts`'s `set_summary_state.py` to support valid wildcard cases.
- Added unit tests in `name_to_name_index` to ensure:
  - Backward compatibility by raising `ValueError` when needed.
  - Correct handling of wildcard indices using `WildcardIndexError`.
