### PR TITLE
DM-48231: Fix issue with kafka Consumer group being left behind when closing application.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - moto >=5
     - {{ pin_compatible('numpy') }}
     - python {{ python }}
-    - python-confluent-kafka =1.9
+    - python-confluent-kafka >=2.0.2
     - pyyaml
     - setuptools
     - setuptools_scm

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,6 @@
 # Confluent schema-registry images:
 # https://github.com/confluentinc/schema-registry-images/tags
 
-version: '3'
 networks:
   kafka:
     name: kafka
@@ -11,7 +10,7 @@ networks:
 services:
 
   broker:
-    image: quay.io/strimzi/kafka:0.36.1-kafka-3.5.1
+    image: quay.io/strimzi/kafka:0.43.0-kafka-3.8.0
     hostname: broker
     container_name: broker
     command: [
@@ -37,7 +36,7 @@ services:
       LOG_DIR: "/tmp/logs"
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.4.0
+    image: confluentinc/cp-schema-registry:7.7.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/python/lsst/ts/salobj/sal_info.py
+++ b/python/lsst/ts/salobj/sal_info.py
@@ -1142,6 +1142,23 @@ class SalInfo:
         self._deserializers_and_contexts = dict()
         self._schema_registry_client = None
 
+        # Delete consumer group
+        broker_client_configuration = self.get_broker_client_configuration()
+
+        broker_client = AdminClient(broker_client_configuration)
+
+        deleted_groups = broker_client.delete_consumer_groups([self.group_id])
+
+        for future in deleted_groups.values():
+            try:
+                self.log.debug("Waiting for consumer group to be deleted.")
+                future.result(timeout=10)
+                self.log.debug("Consumer groups deleted.")
+            except Exception:
+                self.log.exception(
+                    "Error while waiting for consumer group to be deleted."
+                )
+
     async def _read_loop(self) -> None:
         """Read and process messages."""
         self.domain.num_read_loops += 1


### PR DESCRIPTION
Fixing the issue with the consumer groups left behind required updating the confluent-kaka > 2. But we still had that issue with the v2 of the library with the publish delays. After a deep dive into the docs I finally managed to find a solution for it, which allows us now to update to the newest version of the library and also frees us to update to python 3.12.